### PR TITLE
NEWTS-49

### DIFF
--- a/api/src/main/java/org/opennms/newts/api/SampleRepository.java
+++ b/api/src/main/java/org/opennms/newts/api/SampleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, The OpenNMS Group
+ * Copyright 2015, The OpenNMS Group
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -61,5 +61,13 @@ public interface SampleRepository {
      * @param samples
      */
     public void insert(Collection<Sample> samples);
+
+    /**
+     * Write (store) samples.
+     *
+     * @param samples
+     * @param calculateTimeToLive
+     */
+    public void insert(Collection<Sample> samples, boolean calculateTimeToLive);
 
 }


### PR DESCRIPTION
Add an insert method that takes an additional boolean argument that causes the ttl for the value to be calculated for each sample based on the samples timestamp rather than using the global default.