### PR TITLE
NEWTS-75: Use time delta to calculate TTL

### DIFF
--- a/cassandra/storage/src/main/java/org/opennms/newts/persistence/cassandra/CassandraSampleRepository.java
+++ b/cassandra/storage/src/main/java/org/opennms/newts/persistence/cassandra/CassandraSampleRepository.java
@@ -242,7 +242,7 @@ public class CassandraSampleRepository implements SampleRepository {
         for (Sample m : samples) {
             int ttl = m_ttl;
             if (calculateTimeToLive) {
-                ttl -= (int) now.minus(m.getTimestamp()).asSeconds();
+                ttl -= (int) (now.asSeconds() - m.getTimestamp().asSeconds());
                 if (ttl <= 0) {
                     LOG.debug("Skipping expired sample: {}", m);
                     continue;


### PR DESCRIPTION
The previous code used durations to calculate the remaining TTL. This
requires the inserted metric to be in the past. By using the delta the
metric can be from the future and the TTL is extended accordingly.

JIRA: http://issues.opennms.org/browse/NEWTS-75