### PR TITLE
NEWTS-81: Refactor CassandraSession into an interface/implementation

### DIFF
--- a/cassandra/common/src/main/java/org/opennms/newts/cassandra/CassandraSession.java
+++ b/cassandra/common/src/main/java/org/opennms/newts/cassandra/CassandraSession.java
@@ -16,121 +16,27 @@
 package org.opennms.newts.cassandra;
 
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.datastax.driver.core.CloseFuture;
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Cluster.Builder;
 import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.ProtocolOptions.Compression;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.exceptions.DriverException;
 
 
-public class CassandraSession {
+public interface CassandraSession {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CassandraSession.class);
+    PreparedStatement prepare(String statement);
 
-    private final Session m_session;
+    PreparedStatement prepare(RegularStatement statement);
 
-    @Inject
-    public CassandraSession(@Named("cassandra.keyspace") String keyspace, @Named("cassandra.hostname") String hostname,
-            @Named("cassandra.port") int port, @Named("cassandra.compression") String compression,
-            @Named("cassandra.username") String username, @Named("cassandra.password") String password) {
+    ResultSetFuture executeAsync(Statement statement);
 
-        checkNotNull(keyspace, "keyspace argument");
-        checkNotNull(hostname, "hostname argument");
-        checkArgument(port > 0 && port < 65535, "not a valid port number: %d", port);
-        checkNotNull(compression, "compression argument");
+    ResultSet execute(Statement statement);
 
-        LOG.info("Setting up session with {}:{} using compression {}", hostname, port, compression.toUpperCase());
+    ResultSet execute(String statement);
 
-        Builder builder = Cluster
-                .builder()
-                .withPort(port)
-                .addContactPoints(hostname.split(","))
-                .withCompression(Compression.valueOf(compression.toUpperCase()));
-
-        if (username != null && password != null) {
-            LOG.info("Using username: {} and password: XXXXXXXX", username);
-            builder.withCredentials(username, password);
-        }
-
-        m_session = builder.build().connect(keyspace);
-    }
-
-    public PreparedStatement prepare(String statement) {
-        try                           {  return m_session.prepare(statement);  }
-        catch (DriverException excep) {  throw new CassandraException(excep);  } 
-    }
-
-    public PreparedStatement prepare(RegularStatement statement) {
-        try                           {  return m_session.prepare(statement);  }
-        catch (DriverException excep) {  throw new CassandraException(excep);  } 
-    }
-
-    public ResultSetFuture executeAsync(Statement statement) {
-        try                           {  return m_session.executeAsync(statement);  }
-        catch (DriverException excep) {  throw new CassandraException(excep);  } 
-    }
-
-    public ResultSet execute(Statement statement) {
-        try                           {  return m_session.execute(statement);  }
-        catch (DriverException excep) {  throw new CassandraException(excep);  }
-    }
-
-    public ResultSet execute(String statement) {
-        try                           {  return m_session.execute(statement);  }
-        catch (DriverException excep) {  throw new CassandraException(excep);  }
-    }
-
-    public Future<Void> shutdown() {
-        final CloseFuture future = m_session.closeAsync();
-
-        return new Future<Void>() {
-
-            @Override
-            public boolean cancel(boolean mayInterruptIfRunning) {
-                return future.cancel(mayInterruptIfRunning);
-            }
-
-            @Override
-            public boolean isCancelled() {
-                return future.isCancelled();
-            }
-
-            @Override
-            public boolean isDone() {
-                return future.isDone();
-            }
-
-            @Override
-            public Void get() throws InterruptedException, ExecutionException {
-                return future.get();
-            }
-
-            @Override
-            public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-                return future.get(timeout, unit);
-            }
-        };
-
-    }
+    Future<Void> shutdown();
 
 }

--- a/cassandra/common/src/main/java/org/opennms/newts/cassandra/CassandraSessionImpl.java
+++ b/cassandra/common/src/main/java/org/opennms/newts/cassandra/CassandraSessionImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014, The OpenNMS Group
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opennms.newts.cassandra;
+
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.CloseFuture;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ProtocolOptions.Compression;
+import com.datastax.driver.core.RegularStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.DriverException;
+
+
+public class CassandraSessionImpl implements CassandraSession {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraSessionImpl.class);
+
+    private final Session m_session;
+
+    @Inject
+    public CassandraSessionImpl(@Named("cassandra.keyspace") String keyspace, @Named("cassandra.hostname") String hostname,
+            @Named("cassandra.port") int port, @Named("cassandra.compression") String compression,
+            @Named("cassandra.username") String username, @Named("cassandra.password") String password) {
+
+        checkNotNull(keyspace, "keyspace argument");
+        checkNotNull(hostname, "hostname argument");
+        checkArgument(port > 0 && port < 65535, "not a valid port number: %d", port);
+        checkNotNull(compression, "compression argument");
+
+        LOG.info("Setting up session with {}:{} using compression {}", hostname, port, compression.toUpperCase());
+
+        Builder builder = Cluster
+                .builder()
+                .withPort(port)
+                .addContactPoints(hostname.split(","))
+                .withCompression(Compression.valueOf(compression.toUpperCase()));
+
+        if (username != null && password != null) {
+            LOG.info("Using username: {} and password: XXXXXXXX", username);
+            builder.withCredentials(username, password);
+        }
+
+        m_session = builder.build().connect(keyspace);
+    }
+
+    public PreparedStatement prepare(String statement) {
+        try                           {  return m_session.prepare(statement);  }
+        catch (DriverException excep) {  throw new CassandraException(excep);  } 
+    }
+
+    public PreparedStatement prepare(RegularStatement statement) {
+        try                           {  return m_session.prepare(statement);  }
+        catch (DriverException excep) {  throw new CassandraException(excep);  } 
+    }
+
+    public ResultSetFuture executeAsync(Statement statement) {
+        try                           {  return m_session.executeAsync(statement);  }
+        catch (DriverException excep) {  throw new CassandraException(excep);  } 
+    }
+
+    public ResultSet execute(Statement statement) {
+        try                           {  return m_session.execute(statement);  }
+        catch (DriverException excep) {  throw new CassandraException(excep);  }
+    }
+
+    public ResultSet execute(String statement) {
+        try                           {  return m_session.execute(statement);  }
+        catch (DriverException excep) {  throw new CassandraException(excep);  }
+    }
+
+    public Future<Void> shutdown() {
+        final CloseFuture future = m_session.closeAsync();
+
+        return new Future<Void>() {
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return future.cancel(mayInterruptIfRunning);
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return future.isCancelled();
+            }
+
+            @Override
+            public boolean isDone() {
+                return future.isDone();
+            }
+
+            @Override
+            public Void get() throws InterruptedException, ExecutionException {
+                return future.get();
+            }
+
+            @Override
+            public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                return future.get(timeout, unit);
+            }
+        };
+
+    }
+
+}

--- a/cassandra/common/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/cassandra/common/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
     </cm:default-properties>
   </cm:property-placeholder>
 
-  <bean id="cassandraSession" class="org.opennms.newts.cassandra.CassandraSession" >
+  <bean id="cassandraSession" class="org.opennms.newts.cassandra.CassandraSessionImpl" >
     <argument index="0" value="${cassandra.keyspace}" />
     <argument index="1" value="${cassandra.hostname}" />
     <argument index="2" value="${cassandra.port}" />

--- a/cassandra/search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/cassandra/search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-  <reference id="cassandraSession" ext:proxy-method="classes" interface="org.opennms.newts.cassandra.CassandraSession" />
+  <reference id="cassandraSession" interface="org.opennms.newts.cassandra.CassandraSession" />
 
   <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 

--- a/cassandra/search/src/test/java/org/opennms/newts/cassandra/search/CassandraIndexerITCase.java
+++ b/cassandra/search/src/test/java/org/opennms/newts/cassandra/search/CassandraIndexerITCase.java
@@ -50,6 +50,7 @@ import org.opennms.newts.api.search.Term;
 import org.opennms.newts.api.search.TermQuery;
 import org.opennms.newts.cassandra.AbstractCassandraTestCase;
 import org.opennms.newts.cassandra.CassandraSession;
+import org.opennms.newts.cassandra.CassandraSessionImpl;
 import org.opennms.newts.cassandra.ContextConfigurations;
 import org.opennms.newts.cassandra.search.CassandraResourceTreeWalker.SearchResultVisitor;
 
@@ -265,7 +266,7 @@ public class CassandraIndexerITCase extends AbstractCassandraTestCase {
     }
 
     private CassandraSession getCassandraSession() {
-        return new CassandraSession(CASSANDRA_KEYSPACE, CASSANDRA_HOST,
+        return new CassandraSessionImpl(CASSANDRA_KEYSPACE, CASSANDRA_HOST,
                 CASSANDRA_PORT, CASSANDRA_COMPRESSION,
                 CASSANDRA_USERNAME, CASSANDRA_PASSWORD);
     }

--- a/cassandra/storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/cassandra/storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
     </cm:default-properties>
   </cm:property-placeholder>
 
-  <reference id="cassandraSession" ext:proxy-method="classes" interface="org.opennms.newts.cassandra.CassandraSession" />
+  <reference id="cassandraSession" interface="org.opennms.newts.cassandra.CassandraSession" />
 
   <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 

--- a/cassandra/storage/src/test/java/org/opennms/newts/persistence/cassandra/NewtsSampleRepositoryTestCase.java
+++ b/cassandra/storage/src/test/java/org/opennms/newts/persistence/cassandra/NewtsSampleRepositoryTestCase.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.opennms.newts.api.SampleProcessorService;
 import org.opennms.newts.cassandra.AbstractCassandraTestCase;
 import org.opennms.newts.cassandra.CassandraSession;
+import org.opennms.newts.cassandra.CassandraSessionImpl;
 import org.opennms.newts.cassandra.ContextConfigurations;
 
 import com.codahale.metrics.MetricRegistry;
@@ -40,7 +41,7 @@ public class NewtsSampleRepositoryTestCase extends AbstractCassandraTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        CassandraSession session = new CassandraSession(KEYSPACE_NAME, CASSANDRA_HOST,
+        CassandraSession session = new CassandraSessionImpl(KEYSPACE_NAME, CASSANDRA_HOST,
                 CASSANDRA_PORT, CASSANDRA_COMPRESSION,
                 CASSANDRA_USERNAME, CASSANDRA_PASSWORD);
         m_repository = new CassandraSampleRepository(

--- a/examples/stress/src/main/java/org/opennms/newts/stress/InsertDispatcher.java
+++ b/examples/stress/src/main/java/org/opennms/newts/stress/InsertDispatcher.java
@@ -24,6 +24,7 @@ import org.opennms.newts.api.Sample;
 import org.opennms.newts.api.SampleProcessorService;
 import org.opennms.newts.api.SampleRepository;
 import org.opennms.newts.cassandra.CassandraSession;
+import org.opennms.newts.cassandra.CassandraSessionImpl;
 import org.opennms.newts.cassandra.ContextConfigurations;
 import org.opennms.newts.persistence.cassandra.CassandraSampleRepository;
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ class InsertDispatcher extends Dispatcher {
 
         m_config = config;
 
-        CassandraSession session = new CassandraSession(
+        CassandraSession session = new CassandraSessionImpl(
                 config.getCassandraKeyspace(),
                 config.getCassandraHost(),
                 config.getCassandraPort(),

--- a/examples/stress/src/main/java/org/opennms/newts/stress/SelectDispatcher.java
+++ b/examples/stress/src/main/java/org/opennms/newts/stress/SelectDispatcher.java
@@ -26,6 +26,7 @@ import org.opennms.newts.api.Timestamp;
 import org.opennms.newts.api.query.ResultDescriptor;
 import org.opennms.newts.api.query.StandardAggregationFunctions;
 import org.opennms.newts.cassandra.CassandraSession;
+import org.opennms.newts.cassandra.CassandraSessionImpl;
 import org.opennms.newts.cassandra.ContextConfigurations;
 import org.opennms.newts.persistence.cassandra.CassandraSampleRepository;
 
@@ -49,7 +50,7 @@ public class SelectDispatcher extends Dispatcher {
 
         m_config = config;
 
-        CassandraSession session = new CassandraSession(
+        CassandraSession session = new CassandraSessionImpl(
                 config.getCassandraKeyspace(),
                 config.getCassandraHost(),
                 config.getCassandraPort(),


### PR DESCRIPTION
Refactored CassandraSession into a interface/implementation combo so that Apache Aries Blueprint can proxy CassandraSession as an OSGi service without requiring the ext:proxy-method="classes" extension.