### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/api/src/main/java/org/opennms/newts/api/Duration.java
+++ b/api/src/main/java/org/opennms/newts/api/Duration.java
@@ -147,7 +147,7 @@ public class Duration implements Comparable<Duration>, Serializable {
 
     public boolean isMultiple(Duration o) {
         TimeUnit u = Timestamp.finest(getUnit(), o.getUnit());
-        return (this.gte(o) && ((convert(u) % o.convert(u)) == 0));
+        return this.gte(o) && ((convert(u) % o.convert(u)) == 0);
     }
 
     @Override

--- a/api/src/main/java/org/opennms/newts/api/Timestamp.java
+++ b/api/src/main/java/org/opennms/newts/api/Timestamp.java
@@ -85,7 +85,7 @@ public class Timestamp implements Comparable<Timestamp>, Serializable {
     }
 
     public boolean lte(Timestamp other) {
-        return (lt(other) || equals(other));
+        return lt(other) || equals(other);
     }
 
     public boolean gt(Timestamp other) {
@@ -93,7 +93,7 @@ public class Timestamp implements Comparable<Timestamp>, Serializable {
     }
 
     public boolean gte(Timestamp other) {
-        return (gt(other) || equals(other));
+        return gt(other) || equals(other);
     }
 
     public Timestamp stepFloor(long stepSize, TimeUnit units) {

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/LineParser.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/LineParser.java
@@ -108,7 +108,7 @@ public class LineParser {
     }
 
     public boolean isDigit(char ch) {
-        return ('0' <= ch && ch <= '9');
+        return '0' <= ch && ch <= '9';
     }
     
     public String stringAt(String line, int index) {
@@ -194,7 +194,7 @@ public class LineParser {
     }
 
     public static Gauge valueFor(double value, double nan) {
-        return new Gauge((value == nan ? Double.NaN : value));
+        return new Gauge(value == nan ? Double.NaN : value);
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed