### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/cassandra/search/src/main/java/org/opennms/newts/cassandra/search/Constants.java
+++ b/cassandra/search/src/main/java/org/opennms/newts/cassandra/search/Constants.java
@@ -17,6 +17,8 @@ package org.opennms.newts.cassandra.search;
 
 
 class Constants {
+    
+    private Constants() {}
 
     static String DEFAULT_TERM_FIELD = "_all";
 

--- a/cassandra/storage/src/main/java/org/opennms/newts/persistence/cassandra/SchemaConstants.java
+++ b/cassandra/storage/src/main/java/org/opennms/newts/persistence/cassandra/SchemaConstants.java
@@ -17,6 +17,9 @@ package org.opennms.newts.persistence.cassandra;
 
 
 public class SchemaConstants {
+    
+    private SchemaConstants() {}
+    
     public static final String T_SAMPLES = "samples";
 
     public static final String F_CONTEXT = "context";

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/FileIterable.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/FileIterable.java
@@ -40,6 +40,8 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 
 public class FileIterable {
+    
+    private FileIterable() {}
 
     public static FluentIterable<Path> fileTreeWalker(final Path root) {
         return FluentIterable.from(Iterables.concat(groupFilesByDir(root)));

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/FileObservable.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/FileObservable.java
@@ -35,6 +35,8 @@ import rx.functions.Func1;
 
 public class FileObservable {
     
+    private FileObservable() {}
+    
     public static Observable<Path> fileTreeWalker(final Path root) {
         
         return Observable.create(new OnSubscribe<Path>() {

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/Web.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/Web.java
@@ -29,6 +29,8 @@ import com.google.common.collect.Maps;
 
 
 public class Web {
+    
+    private Web() {}
 
     private static final Map<String, String> STATION_IDS = Maps.newHashMap();
     private static final Map<String, String> STATION_NAMES = Maps.newTreeMap();

--- a/rest/src/main/java/org/opennms/newts/rest/NewtsDaemon.java
+++ b/rest/src/main/java/org/opennms/newts/rest/NewtsDaemon.java
@@ -26,6 +26,8 @@ import org.skife.gressil.Daemon;
 
 
 public class NewtsDaemon {
+    
+    private NewtsDaemon() {}
 
     private static class CommandLine {
         @Option(name = "-p", aliases = {"--pid"}, metaVar = "PIDFILE", usage = "Path to PID file (default: newtsd.pid)")

--- a/rest/src/main/java/org/opennms/newts/rest/Transform.java
+++ b/rest/src/main/java/org/opennms/newts/rest/Transform.java
@@ -38,6 +38,8 @@ import com.google.common.collect.Lists;
 
 
 class Transform {
+    
+    private Transform() {}
 
     private static final Function<SampleDTO, Sample> DTO_TO_SAMPLE;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed