### PR TITLE
General code quality fix-2

### DIFF
--- a/cassandra/common/src/main/java/org/opennms/newts/cassandra/SchemaManager.java
+++ b/cassandra/common/src/main/java/org/opennms/newts/cassandra/SchemaManager.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -72,7 +73,7 @@ public class SchemaManager implements AutoCloseable {
         checkNotNull(schema, "schema argument");
         InputStream stream = checkNotNull(schema.getInputStream(), "schema input stream");
 
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
 
         String line, scrubbed;
         StringBuilder statement = new StringBuilder();

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/FileIterable.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/FileIterable.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -234,7 +235,7 @@ public class FileIterable {
             @Override
             public Iterator<String> iterator() {
                 try {
-                    return new LineIterator(new FileReader(path.toFile()));
+                    return new LineIterator(new InputStreamReader(new FileInputStream(path.toFile()), StandardCharsets.UTF_8));
                 } catch (FileNotFoundException e) {
                     throw Throwables.propagate(e);
                 }

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/FileObservable.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/FileObservable.java
@@ -79,7 +79,7 @@ public class FileObservable {
             public void call(Subscriber<? super String> s) {
                 try (BufferedReader in = fileReader(path))
                 {
-                    String line = null;
+                    String line;
                     while ((line = in.readLine()) != null) {
                         if (s.isUnsubscribed()) return;
                         s.onNext(line);
@@ -101,7 +101,7 @@ public class FileObservable {
             public void call(Subscriber<? super String> s) {
                 try (BufferedReader in = zippedFileReader(path))
                 {
-                    String line = null;
+                    String line;
                     while ((line = in.readLine()) != null) {
                         if (s.isUnsubscribed()) return;
                         s.onNext(line);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
squid:S1854 - Dead stores should be removed. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
https://dev.eclipse.org/sonar/rules/show/squid:S1854
 
Please let me know if you have any questions.

Faisal Hameed