### PR TITLE
General code quality fix-3

### DIFF
--- a/api/src/main/java/org/opennms/newts/api/Duration.java
+++ b/api/src/main/java/org/opennms/newts/api/Duration.java
@@ -91,7 +91,7 @@ public class Duration implements Comparable<Duration>, Serializable {
 
             switch (unit) {
                 case "w":
-                    r = Duration.days(value * 7);
+                    r = Duration.days((long)value * 7);
                     break;
                 case "d":
                     r = Duration.days(value);

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/ImportRunner.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/ImportRunner.java
@@ -414,8 +414,7 @@ public class ImportRunner {
     private Observable<Boolean> parMap(Observable<List<Sample>> samples, ExecutorService executorSvc, final MetricRegistry metrics, final Func1<List<Sample>, Boolean> insert) {
         final ListeningExecutorService executor = MoreExecutors.listeningDecorator(executorSvc);
         
-        Observable<Boolean> o = samples
-                .lift(new Operator<ListenableFuture<Boolean>, List<Sample>>() {
+        return samples.lift(new Operator<ListenableFuture<Boolean>, List<Sample>>() {
 
             @Override
             public Subscriber<? super List<Sample>> call(final Subscriber<? super ListenableFuture<Boolean>> s) {
@@ -474,7 +473,6 @@ public class ImportRunner {
             
         });
 
-        return o;
     }
     
 

--- a/examples/gsod/src/main/java/org/opennms/newts/gsod/MergeSort.java
+++ b/examples/gsod/src/main/java/org/opennms/newts/gsod/MergeSort.java
@@ -178,7 +178,7 @@ public class MergeSort {
     }
 
     private CmdLineParser createCmdLineParser() {
-        CmdLineParser parser = new CmdLineParser(this) {
+        return new CmdLineParser(this) {
 
             @SuppressWarnings("rawtypes")
             @Override
@@ -218,7 +218,6 @@ public class MergeSort {
                 super.addArgument(newSetter, a);
             }
         };
-        return parser;
     }
         
         

--- a/queryparser/src/main/java/org/opennms/newts/api/search/query/QueryParserBase.java
+++ b/queryparser/src/main/java/org/opennms/newts/api/search/query/QueryParserBase.java
@@ -32,11 +32,7 @@ public abstract class QueryParserBase {
         try {
             Query q = TopLevelQuery();
             return q != null ? q : new BooleanQuery();
-        } catch (ParseException qpe) {
-            ParseException e = new ParseException("Cannot parse '" + query + "': " + qpe.getMessage());
-            e.initCause(qpe);
-            throw e;
-        } catch (TokenMgrError qpe) {
+        } catch (ParseException|TokenMgrError qpe) {
             ParseException e = new ParseException("Cannot parse '" + query + "': " + qpe.getMessage());
             e.initCause(qpe);
             throw e;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
squid:S2147 - Catches should be combined.
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S2147
https://dev.eclipse.org/sonar/rules/show/squid:S2184

Please let me know if you have any questions.
 
Faisal Hameed