### PR TITLE
NMS-13029: Re-insert resource metadata for TTL

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,8 @@
+1.5.4
+~~~~~
+
+Respect remaining TTL while caching resource metadata.
+
 1.5.3
 ~~~~~
 

--- a/cassandra/search/src/test/java/org/opennms/newts/cassandra/search/GuavaResourceMetadataTest.java
+++ b/cassandra/search/src/test/java/org/opennms/newts/cassandra/search/GuavaResourceMetadataTest.java
@@ -39,25 +39,27 @@ public class GuavaResourceMetadataTest {
 
         assertThat(cache.get(c, r).isPresent(), not(true));
 
-        cache.merge(c, r, new ResourceMetadata());
+        cache.merge(c, r, new ResourceMetadata().setExpires(200L));
 
         assertThat(cache.get(c, r).isPresent(), is(true));
         assertThat(cache.get(c, r).get().containsMetric("m0"), not(true));
         assertThat(cache.get(c, r).get().containsMetric("m1"), not(true));
+        assertThat(cache.get(c, r).get().getExpires(), is(200L));
 
-        cache.merge(c, r, new ResourceMetadata().putMetric("m0").putMetric("m1"));
+        cache.merge(c, r, new ResourceMetadata().setExpires(100L).putMetric("m0").putMetric("m1"));
 
         assertThat(cache.get(c, r).get().containsMetric("m0"), is(true));
         assertThat(cache.get(c, r).get().containsMetric("m1"), is(true));
         assertThat(cache.get(c, r).get().containsAttribute("meat", "beef"), not(true));
         assertThat(cache.get(c, r).get().containsAttribute("pudding", "bread"), not(true));
+        assertThat(cache.get(c, r).get().getExpires(), is(100L));
 
-        cache.merge(c, r, new ResourceMetadata().putAttribute("meat", "beef"));
-        cache.merge(c, r, new ResourceMetadata().putAttribute("pudding", "bread"));
+        cache.merge(c, r, new ResourceMetadata().setExpires(500L).putAttribute("meat", "beef"));
+        cache.merge(c, r, new ResourceMetadata().setExpires(400L).putAttribute("pudding", "bread"));
 
         assertThat(cache.get(c, r).get().containsAttribute("meat", "beef"), is(true));
         assertThat(cache.get(c, r).get().containsAttribute("pudding", "bread"), is(true));
-
+        assertThat(cache.get(c, r).get().getExpires(), is(100L));
     }
 
 }


### PR DESCRIPTION
The resource metadata cache now respects the TTL used to store the resource metadata. By expiring the cache before the TTL ends, the resource metadata will be re-inserted and therefore the TTL will be expanded.

JIRA: https://issues.opennms.org/browse/NMS-13029