### PR TITLE
NEWTS-114: increase guava bundle range to 18 through less-than-26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
     resource_class: xlarge
 
     environment:
-      MAVEN_OPTS: -Xmx4096m -XX:+UseParallelGC
+      MAVEN_OPTS: -Xmx4096m -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:-UseGCOverheadLimit
 
     steps:
       - cached_checkout

--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -25,7 +25,7 @@
 	      org.opennms.newts.aggregate* 
 	    </Export-Package>
 	    <Import-Package>
-	      *
+	      <![CDATA[com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
 	    </Import-Package>
 	    <Bundle-DocURL>https://newts.io</Bundle-DocURL>
 	  </instructions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,7 @@
 	      org.opennms.newts.api* 
 	    </Export-Package>
 	    <Import-Package>
-	      <![CDATA[javax.inject*;resolution:=optional,*]]>
+	      <![CDATA[javax.inject*;resolution:=optional,com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
 	    </Import-Package>
 	    <Bundle-DocURL>https://newts.io</Bundle-DocURL>
 	  </instructions>

--- a/cassandra/common/pom.xml
+++ b/cassandra/common/pom.xml
@@ -86,7 +86,7 @@
 	      org.opennms.newts.cassandra*
 	    </Export-Package>
 	    <Import-Package>
-	      <![CDATA[javax.inject*;resolution:=optional,*]]>
+	      <![CDATA[javax.inject*;resolution:=optional,com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
 	    </Import-Package>
 	    <Bundle-DocURL>https://newts.io</Bundle-DocURL>
 	  </instructions>

--- a/cassandra/search/pom.xml
+++ b/cassandra/search/pom.xml
@@ -78,7 +78,7 @@
 	      org.opennms.newts.cassandra.search*
 	    </Export-Package>
 	    <Import-Package>
-	      <![CDATA[javax.inject*;resolution:=optional,*]]>
+	      <![CDATA[javax.inject*;resolution:=optional,com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
 	    </Import-Package>
 	    <Bundle-DocURL>https://newts.io</Bundle-DocURL>
 	  </instructions>

--- a/cassandra/storage/pom.xml
+++ b/cassandra/storage/pom.xml
@@ -83,7 +83,7 @@
 	      org.opennms.newts.persistence.cassandra*
 	    </Export-Package>
 	    <Import-Package>
-	      <![CDATA[javax.inject*;resolution:=optional,*]]>
+	      <![CDATA[javax.inject*;resolution:=optional,com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
 	    </Import-Package>
 	    <Bundle-DocURL>https://newts.io</Bundle-DocURL>
 	  </instructions>

--- a/graphite/pom.xml
+++ b/graphite/pom.xml
@@ -25,7 +25,7 @@
               org.opennms.newts.graphite*
             </Export-Package>
             <Import-Package>
-	            <![CDATA[javax.inject*;resolution:=optional,*]]>
+	            <![CDATA[javax.inject*;resolution:=optional,com.google.common.*;version="[${guavaVersion},${maxGuavaVersion})",*]]>
             </Import-Package>
             <Bundle-DocURL>https://newts.io</Bundle-DocURL>
           </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <cassandraDriverVersion>3.5.0</cassandraDriverVersion>
     <guavaVersion>18.0</guavaVersion>
+    <maxGuavaVersion>26</maxGuavaVersion>
     <guiceVersion>4.0</guiceVersion>
     <jacksonVersion>2.5.4</jacksonVersion>
     <junitVersion>4.13.1</junitVersion>


### PR DESCRIPTION
This PR changes the `Import-Package` metadata in the Newts bundle(s) to allow for up to Guava 25.1.

To go beyond 25.1, we'll need to move to the 4.x or higher cassandra driver.

JIRA: https://issues.opennms.org/browse/NEWTS-114